### PR TITLE
nestedOpt function to make it easy to create `Option`s that are themselves `Options`

### DIFF
--- a/src/Data/Options.purs
+++ b/src/Data/Options.purs
@@ -67,7 +67,7 @@ opt = Op <<< defaultToOptions
 -- | Creates a nested `Option`; that is, an `Option` whose value is itself an
 -- | `Options` object.
 nestedOpt :: forall opt1 opt2. String -> Option opt1 (Options opt2)
-nestedOpt k = Op \d -> defaultToOptions k (options d)
+nestedOpt o = Op \d -> defaultToOptions o (options d)
 
 -- | Create a `tag`, by fixing an `Option` to a single value.
 tag :: forall opt value. Option opt value -> value -> Option opt Unit

--- a/src/Data/Options.purs
+++ b/src/Data/Options.purs
@@ -67,7 +67,7 @@ opt = Op <<< defaultToOptions
 -- | Creates a nested `Option`; that is, an `Option` whose value is itself an
 -- | `Options` object.
 nestedOpt :: forall opt1 opt2. String -> Option opt1 (Options opt2)
-nestedOpt o = Op \d -> defaultToOptions o (options d)
+nestedOpt o = Op \innerOptions -> defaultToOptions o (options innerOptions)
 
 -- | Create a `tag`, by fixing an `Option` to a single value.
 tag :: forall opt value. Option opt value -> value -> Option opt Unit

--- a/src/Data/Options.purs
+++ b/src/Data/Options.purs
@@ -6,6 +6,7 @@ module Data.Options
   , assoc, (:=)
   , optional
   , opt
+  , nestedOpt
   , tag
   , defaultToOptions
   ) where
@@ -62,6 +63,11 @@ optional option = Op $ maybe mempty (option :=)
 -- | the given key, which passes the given value through unchanged.
 opt :: forall opt value. String -> Option opt value
 opt = Op <<< defaultToOptions
+
+-- | Creates a nested `Option`; that is, an `Option` whose value is itself an
+-- | `Options` object.
+nestedOpt :: forall opt1 opt2. String -> Option opt1 (Options opt2)
+nestedOpt k = Op \d -> defaultToOptions k (options d)
 
 -- | Create a `tag`, by fixing an `Option` to a single value.
 tag :: forall opt value. Option opt value -> value -> Option opt Unit

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -18,7 +18,7 @@ instance shapeShow :: Show Shape where
   show Triangle = "triangle"
 
 foreign import data Foo :: *
-foreign import data Foo2 :: *
+foreign import data NestedBar :: *
 
 foo :: Option Foo String
 foo = opt "foo"
@@ -44,14 +44,14 @@ buz = opt "buz"
 fuz :: Option Foo (Array Shape)
 fuz = cmap (map show) (opt "fuz")
 
-foo2 :: Option Foo (Options Foo2)
-foo2 = nestedOpt "foo2"
+nestedBar :: Option Foo (Options NestedBar)
+nestedBar = nestedOpt "nestedBar"
 
-foo2bar :: Option Foo2 String
-foo2bar = opt "foo2bar"
+innerBar :: Option NestedBar String
+innerBar = opt "innerBar"
 
-foo2baz :: Option Foo2 Int
-foo2baz = opt "foo2baz"
+innerBaz :: Option NestedBar Int
+innerBaz = opt "innerBaz"
 
 opts :: Options Foo
 opts = foo := "aaa" <>
@@ -62,10 +62,10 @@ opts = foo := "aaa" <>
        biz := Square <>
        buz := (\a b c -> a + b + c) <>
        fuz := [Square, Circle, Triangle] <>
-       foo2 := foo2values
-  where foo2values =
-    foo2bar := "foo2bar" <>
-    foo2baz := 2
+       nestedBar := nestedBarOptions
+  where nestedBarOptions =
+    innerBar := "the inner bar" <>
+    innerBaz := 2
 
 main :: forall eff. Eff (console :: CONSOLE | eff) Unit
 main = log <<< showForeign <<< options $ opts

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,7 +8,7 @@ import Control.Monad.Eff.Console (CONSOLE(), log)
 import Data.Foreign (Foreign())
 import Data.Functor.Contravariant (cmap)
 import Data.Maybe (Maybe(..))
-import Data.Options (Option(), Options(), optional, options, opt, (:=))
+import Data.Options (Option(), Options(), optional, options, opt, nestedOpt, (:=))
 
 data Shape = Circle | Square | Triangle
 
@@ -18,6 +18,7 @@ instance shapeShow :: Show Shape where
   show Triangle = "triangle"
 
 foreign import data Foo :: *
+foreign import data Foo2 :: *
 
 foo :: Option Foo String
 foo = opt "foo"
@@ -43,6 +44,15 @@ buz = opt "buz"
 fuz :: Option Foo (Array Shape)
 fuz = cmap (map show) (opt "fuz")
 
+foo2 :: Option Foo (Options Foo2)
+foo2 = nestedOpt "foo2"
+
+foo2bar :: Option Foo2 String
+foo2bar = opt "foo2bar"
+
+foo2baz :: Option Foo2 Int
+foo2baz = opt "foo2baz"
+
 opts :: Options Foo
 opts = foo := "aaa" <>
        bar := 10 <>
@@ -51,7 +61,11 @@ opts = foo := "aaa" <>
        fiz := Nothing <>
        biz := Square <>
        buz := (\a b c -> a + b + c) <>
-       fuz := [Square, Circle, Triangle]
+       fuz := [Square, Circle, Triangle] <>
+       foo2 := foo2values
+  where foo2values =
+    foo2bar := "foo2bar" <>
+    foo2baz := 2
 
 main :: forall eff. Eff (console :: CONSOLE | eff) Unit
 main = log <<< showForeign <<< options $ opts


### PR DESCRIPTION
I am playing around with options and kept running into the case where I wanted an `Option` that was itself an `Options` object. like

``` javascript
var options = {
  name: "purescript",
  nameOptions: {
    lowercase: true,
    length: 10
  }
}
```

I ended up writing a `nestedOpt` function, and it seemed like the sort of thing that might be useful to other people, so here it is. If it's not useful (or if it duplicates functionality I somehow missed, or if it's not a good approach), feel free to ignore it, and if it needs any changes or renamings, just let me know.
