### PR TITLE
Add roles declarations to forbid unsafe coercions

### DIFF
--- a/src/Data/Options.purs
+++ b/src/Data/Options.purs
@@ -118,6 +118,8 @@ import Foreign.Object as Object
 -- | API are not accidentally passed to some other API.
 newtype Options opt = Options (Array (Tuple String Foreign))
 
+type role Options nominal
+
 derive instance newtypeOptions :: Newtype (Options opt) _
 derive newtype instance semigroupOptions ∷ Semigroup (Options opt)
 derive newtype instance monoidOptions ∷ Monoid (Options opt)


### PR DESCRIPTION
This prevents terms of type `Option a` to be coerced to type `Option b`. The reasoning being that two arbitrary types may not describe the same set of options.
