### PR TITLE
Remove last remnant of `Eff` from the module docs

### DIFF
--- a/src/Data/Options.purs
+++ b/src/Data/Options.purs
@@ -22,7 +22,7 @@
 -- | usually the case that any subset of these properties can be specified;
 -- | however, a value of  type `{ flags :: String, defaultEncoding :: String, [...] }`
 -- | must include every property listed, even if you only want to specify
--- | one or two properties. 
+-- | one or two properties.
 -- |
 -- | ## Using this Library
 -- |
@@ -61,7 +61,7 @@
 -- | suitable representation for passing to the JavaScript API.
 -- |
 -- | ```
--- | createWriteStream :: forall eff. FilePath -> Options CreateWriteStreamOptions -> Effect Unit
+-- | createWriteStream :: FilePath -> Options CreateWriteStreamOptions -> Effect Unit
 -- | createWriteStream path opts = createWriteStreamImpl path (options opts)
 -- | ```
 -- |


### PR DESCRIPTION
**Description of the change**

This PR removes a stray `forall eff.` (that somehow managed to survive the switch from row-based `Eff` to `Effect`) from the module documentation. 😊