### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#45 by @thomashoneyman)
 
 ## [v6.0.0](https://github.com/purescript-contrib/purescript-options/releases/tag/v6.0.0) - 2021-02-26
 

--- a/src/Data/Options.purs
+++ b/src/Data/Options.purs
@@ -97,7 +97,8 @@ module Data.Options
   ( Options(..)
   , options
   , Option
-  , assoc, (:=)
+  , assoc
+  , (:=)
   , optional
   , opt
   , tag
@@ -122,8 +123,8 @@ newtype Options opt = Options (Array (Tuple String Foreign))
 type role Options nominal
 
 derive instance newtypeOptions :: Newtype (Options opt) _
-derive newtype instance semigroupOptions ∷ Semigroup (Options opt)
-derive newtype instance monoidOptions ∷ Monoid (Options opt)
+derive newtype instance semigroupOptions :: Semigroup (Options opt)
+derive newtype instance monoidOptions :: Monoid (Options opt)
 
 -- | Convert an `Options` value into a JavaScript object, suitable for passing
 -- | to JavaScript APIs.
@@ -164,4 +165,4 @@ tag o value = Op \_ -> o := value
 -- | you need some other behaviour, you can write your own function to replace
 -- | this one, and construct an `Option` yourself.
 defaultToOptions :: forall opt value. String -> value -> Options opt
-defaultToOptions k v = Options [Tuple k (unsafeToForeign v)]
+defaultToOptions k v = Options [ Tuple k (unsafeToForeign v) ]

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -44,14 +44,15 @@ anArrayOfShapesOption :: Option MyOptions (Array Shape)
 anArrayOfShapesOption = cmap (map show) (opt "anArrayOfShapesOption")
 
 myOptions :: Options MyOptions
-myOptions = aStringOption := "aaa" <>
-       anIntOption := 10 <>
-       aBooleanOption := true <>
-       anOptionalStringOption := Just "c" <>
-       anotherOptionalStringOption := Nothing <>
-       aShapeOption := Square <>
-       aFunctionOption := (\a b c -> a + b + c) <>
-       anArrayOfShapesOption := [Square, Circle, Triangle]
+myOptions = aStringOption := "aaa"
+  <> anIntOption := 10
+  <> aBooleanOption := true
+  <> anOptionalStringOption := Just "c"
+  <> anotherOptionalStringOption := Nothing
+  <> aShapeOption := Square
+  <> aFunctionOption := (\a b c -> a + b + c)
+  <>
+    anArrayOfShapesOption := [ Square, Circle, Triangle ]
 
 foreign import showForeign :: Foreign -> String
 
@@ -76,46 +77,46 @@ shouldEqual actual expected = assertEqual { actual, expected }
 
 main :: Effect Unit
 main = do
-        describe "end-to-end" do
-          it "works as expected" do
-            let expected = """{"aStringOption":"aaa","anIntOption":10,"aBooleanOption":true,"anOptionalStringOption":"c","shape":"square","anArrayOfShapesOption":["square","circle","triangle"]}"""
-            let actual = showForeign $ options myOptions
+  describe "end-to-end" do
+    it "works as expected" do
+      let expected = """{"aStringOption":"aaa","anIntOption":10,"aBooleanOption":true,"anOptionalStringOption":"c","shape":"square","anArrayOfShapesOption":["square","circle","triangle"]}"""
+      let actual = showForeign $ options myOptions
 
-            actual `shouldEqual` expected
-        describe "opt" do
-          it "works with `String`s" do
-            let expected = """{"aStringOption":"hello, world"}"""
-            let actual = showForeign $ options $ (:=) aStringOption "hello, world"
+      actual `shouldEqual` expected
+  describe "opt" do
+    it "works with `String`s" do
+      let expected = """{"aStringOption":"hello, world"}"""
+      let actual = showForeign $ options $ (:=) aStringOption "hello, world"
 
-            actual `shouldEqual` expected
-          it "works with `Int`s" do
-            let expected = """{"anIntOption":74}"""
-            let actual = showForeign $ options $ (:=) anIntOption 74
+      actual `shouldEqual` expected
+    it "works with `Int`s" do
+      let expected = """{"anIntOption":74}"""
+      let actual = showForeign $ options $ (:=) anIntOption 74
 
-            actual `shouldEqual` expected
-          it "works with `Boolean`s" do
-            let expected = """{"aBooleanOption":true}"""
-            let actual = showForeign $ options $ (:=) aBooleanOption true
+      actual `shouldEqual` expected
+    it "works with `Boolean`s" do
+      let expected = """{"aBooleanOption":true}"""
+      let actual = showForeign $ options $ (:=) aBooleanOption true
 
-            actual `shouldEqual` expected
-          it "works with `Array`s" do
-            let expected = """{"anArrayOfShapesOption":["square","circle","triangle"]}"""
-            let actual = showForeign $ options $ (:=) anArrayOfShapesOption [Square, Circle, Triangle]
+      actual `shouldEqual` expected
+    it "works with `Array`s" do
+      let expected = """{"anArrayOfShapesOption":["square","circle","triangle"]}"""
+      let actual = showForeign $ options $ (:=) anArrayOfShapesOption [ Square, Circle, Triangle ]
 
-            actual `shouldEqual` expected
-          it "does nothing for functions" do
-            let expected = """{}"""
-            let actual = showForeign $ options $ (:=) aFunctionOption (\a b c -> a + b + c)
+      actual `shouldEqual` expected
+    it "does nothing for functions" do
+      let expected = """{}"""
+      let actual = showForeign $ options $ (:=) aFunctionOption (\a b c -> a + b + c)
 
-            actual `shouldEqual` expected
-        describe "optional" do
-          it "includes the option when it is provided" do
-            let expected = """{"anotherOptionalStringOption":"provided"}"""
-            let actual = showForeign $ options $ (:=) anotherOptionalStringOption $ Just "provided"
+      actual `shouldEqual` expected
+  describe "optional" do
+    it "includes the option when it is provided" do
+      let expected = """{"anotherOptionalStringOption":"provided"}"""
+      let actual = showForeign $ options $ (:=) anotherOptionalStringOption $ Just "provided"
 
-            actual `shouldEqual` expected
-          it "excludes the option when it is not provided" do
-            let expected = """{}"""
-            let actual = showForeign $ options $ (:=) anotherOptionalStringOption Nothing
+      actual `shouldEqual` expected
+    it "excludes the option when it is not provided" do
+      let expected = """{}"""
+      let actual = showForeign $ options $ (:=) anotherOptionalStringOption Nothing
 
-            actual `shouldEqual` expected
+      actual `shouldEqual` expected


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
